### PR TITLE
Remove reference to rails and bootstrap helper gems.

### DIFF
--- a/app/helpers/ucb_rails_user/users_helper.rb
+++ b/app/helpers/ucb_rails_user/users_helper.rb
@@ -14,5 +14,8 @@ module UcbRailsUser
       )
     end
 
+    def checkmark(bool, true_string="&#10004;".html_safe, false_string="nbsp;".html_safe)
+      bool ? true_string : false_string
+    end
   end
 end

--- a/app/helpers/ucb_rails_user/users_helper.rb
+++ b/app/helpers/ucb_rails_user/users_helper.rb
@@ -14,7 +14,7 @@ module UcbRailsUser
       )
     end
 
-    def checkmark(bool, true_string="&#10004;".html_safe, false_string="nbsp;".html_safe)
+    def checkmark(bool, true_string="&#10004;".html_safe, false_string='&nbsp;'.html_safe)
       bool ? true_string : false_string
     end
   end

--- a/app/views/ucb_rails_user/users/_form.html.haml
+++ b/app/views/ucb_rails_user/users/_form.html.haml
@@ -4,11 +4,11 @@
   = f.input :last_name, :input_html => {disabled: 'disabled'}
   = f.input :email, :input_html => {disabled: 'disabled'}
   = f.input :alternate_email
-  = f.input :last_login_at, as: :string, :input_html => {disabled: 'disabled', value: datetime_to_s(@user.last_login_at, :long)}
+  = f.input :last_login_at, as: :string, :input_html => {disabled: 'disabled', value: @user.last_login_at&.strftime("%m/%d/%Y %H:%M:%S")}
   = f.input :superuser_flag, :as => :boolean, label: "Superuser?", wrapper: :horizontal_boolean
   = f.input :inactive_flag, :as => :boolean, :label => "Inactive User?", wrapper: :horizontal_boolean
 
-  = form_actions do
-    = submit_button_tag("Update User")
-    = cancel_button_tag(url: admin_users_path)
+  .form-actions
+    %button{type: "submit", class: "btn btn-primary"} Submit
+    = link_to "Cancel", admin_users_path
 

--- a/app/views/ucb_rails_user/users/_user.html.haml
+++ b/app/views/ucb_rails_user/users/_user.html.haml
@@ -1,10 +1,10 @@
 %tr[user]
-  = td_bln(user.superuser?)
-  = td_bln(user.inactive?)
+  %td= checkmark(user.superuser?)
+  %td= checkmark(user.inactive?)
   %td= user.first_name
   %td= user.last_name
   %td= mail_to(user.email)
-  %td.dt= datetime_to_s(user.last_login_at, :long)
+  %td.dt= user.last_login_at&.strftime("%m/%d/%Y %H:%M:%S")
   %td.min= user.ldap_uid
   %td.min= user.employee_id
   %td= link_to('edit', edit_admin_user_path(user), :class => 'btn btn-default btn-xs', :id => dom_id(user, 'edit'))

--- a/lib/ucb_rails_user.rb
+++ b/lib/ucb_rails_user.rb
@@ -8,9 +8,6 @@ require "omniauth-cas"
 require "ucb_ldap"
 require "active_attr"
 
-require "bootstrap-view-helpers"
-#require "rails_view_helpers"
-
 module UcbRailsUser
 
   def self.logger

--- a/ucb_rails_user.gemspec
+++ b/ucb_rails_user.gemspec
@@ -29,11 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ucb_ldap", "~> 3.0"
 
-  # TODO: it would be nice to remove these, but that involves some rewriting
-  s.add_dependency "bootstrap-view-helpers", "~> 0.0.14"
-  # This is pinned to Rails 4 - we have a Rails 5 branch, so it will have to go into the Gemfile of the host
-  #s.add_dependency "rails_view_helpers", "~> 0.0.4"
-
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency "rspec-rails", "~> 3.5"
 end


### PR DESCRIPTION
@darinwilson This in conjunction with https://github.com/ucb-ist-eas/ucb_rails_cli/pull/11 should remove both `bootstrap-view-helpers` & `rails_view_helpers`