### PR TITLE
Change edit button style in user admin screen

### DIFF
--- a/app/views/ucb_rails_user/users/_user.html.haml
+++ b/app/views/ucb_rails_user/users/_user.html.haml
@@ -7,6 +7,6 @@
   %td.dt= user.last_login_at&.strftime("%m/%d/%Y %H:%M:%S")
   %td.min= user.ldap_uid
   %td.min= user.employee_id
-  %td= link_to('edit', edit_admin_user_path(user), :class => 'btn btn-default btn-xs', :id => dom_id(user, 'edit'))
+  %td= link_to('edit', edit_admin_user_path(user), :class => 'btn btn-info btn-xs', :id => dom_id(user, 'edit'))
   %td= link_to('delete', admin_user_path(user), :data => {confirm: 'Are you sure?'}, :method => :delete, :class => 'btn btn-xs btn-danger')
 


### PR DESCRIPTION
The background of `btn-default` is exactly the same as the dark background in a striped table, so the "edit" button on the user admin screen was not looking like a button in every other table row.

This changes the style from `btn-default` to `btn-info` so it looks like a button again.