### PR TITLE
Don't raise if skip_before_action can't find method

### DIFF
--- a/app/controllers/ucb_rails_user/concerns/home_controller.rb
+++ b/app/controllers/ucb_rails_user/concerns/home_controller.rb
@@ -2,7 +2,7 @@ module UcbRailsUser::Concerns::HomeController
   extend ActiveSupport::Concern
 
   included do
-    skip_before_action :ensure_authenticated_user
+    skip_before_action :ensure_authenticated_user, raise: false
   end
 
   def index

--- a/app/controllers/ucb_rails_user/concerns/sessions_controller.rb
+++ b/app/controllers/ucb_rails_user/concerns/sessions_controller.rb
@@ -2,7 +2,7 @@ module UcbRailsUser::Concerns::SessionsController
   extend ActiveSupport::Concern
 
   included do
-    skip_before_action :ensure_authenticated_user, :log_request
+    skip_before_action :ensure_authenticated_user, :log_request, raise: false
   end
 
   # Redirects to authentication provider

--- a/app/controllers/ucb_rails_user/concerns/users_controller.rb
+++ b/app/controllers/ucb_rails_user/concerns/users_controller.rb
@@ -4,7 +4,7 @@ module UcbRailsUser::Concerns::UsersController
   included do
     before_action :find_user, :only => [:edit, :update, :destroy]
     before_action :ensure_admin_user
-    skip_before_action :ensure_admin_user, if: ->{ action_name == "toggle_superuser" && Rails.env.development? }
+    skip_before_action :ensure_admin_user, if: ->{ action_name == "toggle_superuser" && Rails.env.development? }, raise: false
   end
 
   def index


### PR DESCRIPTION
This fixes a strange bug that would cause host apps to raise an error saying it couldn't find the ensure_authenticated_user method. 

This fix was suggested here: https://github.com/thoughtbot/clearance/issues/621