### PR TITLE
Convert LDAP string to Ruby string

### DIFF
--- a/app/controllers/ucb_rails_user/concerns/users_controller.rb
+++ b/app/controllers/ucb_rails_user/concerns/users_controller.rb
@@ -90,7 +90,8 @@ module UcbRailsUser::Concerns::UsersController
         params.fetch(:last_name),
         :sort => :last_first_downcase
       )
-      @lps_existing_uids = User.where(ldap_uid: @lps_entries.map(&:uid)).pluck(:uid)
+      uid_strings = @lps_entries.map { |entry| entry.uid&.to_s }.compact
+      @lps_existing_uids = User.where(ldap_uid: uid_strings).pluck(:uid)
       render 'ucb_rails_user/lps/search'
     end
 


### PR DESCRIPTION
Sometimes LDAP returns a string-like object in its results that Ruby (and especially ActiveRecord) doesn't like. This adds the needed conversion.