### PR TITLE
Compute unsorted user columns based on class/text and bump to version 4.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.0.6
+-----
+
+Add support for customizing which columns in the user admin section are not sorted. ([PR #60](https://github.com/ucb-ist-eas/ucb_rails_user/pull/60))
+
 4.0.5
 -----
 

--- a/app/assets/javascripts/ucb_rails_user/ucb_rails_user.js
+++ b/app/assets/javascripts/ucb_rails_user/ucb_rails_user.js
@@ -18,11 +18,16 @@ var addDatatablesToSearchResults = function () {
 }
 
 var addDatatablesToUsersTable = function () {
+  var unsorted_columns = $('.ucb-rails-users-table th.unsorted').map((i, e) => $(e).index()).toArray()
+  if (unsorted_columns === []) {
+    var unsorted_columns = $(".ucb-rails-users-table th:contains('Edit'),.ucb-rails-users-table th:contains('Delete')").map((i, e) => $(e).index()).toArray()
+  }
+
   $('.ucb-rails-users-table').dataTable({
     searching: true,
     order: [[ 3, "asc" ]],
     columnDefs: [ {
-      targets: [8, 9],
+      targets: unsorted_columns,
       orderable: false
     }],
   })

--- a/app/views/ucb_rails_user/users/index.html.haml
+++ b/app/views/ucb_rails_user/users/index.html.haml
@@ -14,8 +14,8 @@
         %th.dt Last Login
         %th UID
         %th Employee ID
-        %th.min Edit
-        %th.min Delete
+        %th.min.unsorted Edit
+        %th.min.unsorted Delete
     %tbody.highlight
       = render partial: "ucb_rails_user/users/user", collection: @users
 

--- a/lib/ucb_rails_user/version.rb
+++ b/lib/ucb_rails_user/version.rb
@@ -1,3 +1,3 @@
 module UcbRailsUser
-  VERSION = '4.0.5'
+  VERSION = '4.0.6'
 end


### PR DESCRIPTION
This branch adds support for customizing which columns in the user admin section are not sorted.  Columns are sorted by default, but instead of hard-coding the column indices `[8,9]` as the columns to not sort in DataTables, you now specify which columns to skip by applying the `unsorted` class to the `<th>` element.  If no columns have this class, then the code falls back to using the columns containing 'Edit' and 'Delete' in the header row.
