### PR TITLE
Improve scoping of custom "Add New" button to users screen

### DIFF
--- a/app/assets/javascripts/ucb_rails_user/ucb_rails_user.js
+++ b/app/assets/javascripts/ucb_rails_user/ucb_rails_user.js
@@ -32,7 +32,7 @@ var addDatatablesToUsersTable = function () {
     }],
   })
   var addNewHtml = '&nbsp;&nbsp;<a href="/admin/users/new" class="btn btn-primary">Add New</a>'
-  $('#DataTables_Table_0_filter').append(addNewHtml)
+  $('.ucb-rails-users-table-wrapper #DataTables_Table_0_filter').append(addNewHtml)
 }
 
 var resetImpersonateButton = function() {

--- a/app/views/ucb_rails_user/users/index.html.haml
+++ b/app/views/ucb_rails_user/users/index.html.haml
@@ -2,7 +2,7 @@
   %h1
     Users
 
-.table-responsive
+.table-responsive.ucb-rails-users-table-wrapper
   %table.table.table-striped.table-bordered.table-hover.ucb-rails-users-table
     %thead
       %tr


### PR DESCRIPTION
We're placing the "Add New" button on the admin users screen by hacking the DataTables header. However, the CSS selector we were using was too broad, causing "Add New" to be added to any DataTables table.

This adds a wrapper class to the containing div, and changes the JavaScript to use a more specific selector when adding the button.

Fixes #21 