### PR TITLE
Create user from employee_id as well as ldap UID

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ucb_rails_user (4.0.7)
+    ucb_rails_user (4.1.0)
       active_attr (~> 0.10)
       faraday (~> 1.0)
       haml (~> 5.0)
@@ -119,25 +119,29 @@ GEM
       railties (>= 5.0.0)
     faker (2.20.0)
       i18n (>= 1.8.11, < 2)
-    faraday (1.8.0)
+    faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
     haml (5.2.2)
@@ -171,7 +175,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.3)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -190,6 +194,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.6-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
@@ -265,7 +271,7 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    sprockets (4.0.3)
+    sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -277,7 +283,7 @@ GEM
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.10)
-    timeout (0.2.0)
+    timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     ucb_ldap (3.1.1)
@@ -290,6 +296,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
   x86_64-darwin-19
 

--- a/app/models/ucb_rails_user/user_uc_path_service.rb
+++ b/app/models/ucb_rails_user/user_uc_path_service.rb
@@ -67,7 +67,10 @@ class UcbRailsUser::UserUcPathService
 
     def initialize
       credentials =
-        Rails.application.credentials.ucpath || Rails.application.credentials.hcm
+        Rails.application.credentials.ucpath&.with_indifferent_access || Rails.application.credentials.hcm&.with_indifferent_access
+      if credentials.has_key?(Rails.env)
+        credentials = credentials[Rails.env]
+      end
       @app_id  = credentials&.fetch(:app_id)
       @app_key = credentials&.fetch(:app_key)
       @endpoint = credentials&.fetch(:endpoint)

--- a/app/models/ucb_rails_user/user_uc_path_service.rb
+++ b/app/models/ucb_rails_user/user_uc_path_service.rb
@@ -66,14 +66,12 @@ class UcbRailsUser::UserUcPathService
     attr_reader :app_id, :app_key, :endpoint
 
     def initialize
-      credentials =
+      base_credentials =
         Rails.application.credentials.ucpath&.with_indifferent_access || Rails.application.credentials.hcm&.with_indifferent_access
-      if credentials.has_key?(Rails.env)
-        credentials = credentials[Rails.env]
-      end
-      @app_id  = credentials&.fetch(:app_id)
-      @app_key = credentials&.fetch(:app_key)
-      @endpoint = credentials&.fetch(:endpoint)
+      env_credentials = base_credentials&.fetch(Rails.env) || {}
+      @app_id  = env_credentials&.fetch(:app_id, nil) || base_credentials&.fetch(:app_id, nil)
+      @app_key = env_credentials&.fetch(:app_key, nil) || base_credentials&.fetch(:app_key, nil)
+      @endpoint = env_credentials&.fetch(:endpoint, nil) || base_credentials&.fetch(:endpoint, nil)
     end
 
     def fetch_employee_data_with_ldap_uid(ldap_uid)

--- a/app/models/ucb_rails_user/user_uc_path_service.rb
+++ b/app/models/ucb_rails_user/user_uc_path_service.rb
@@ -67,8 +67,10 @@ class UcbRailsUser::UserUcPathService
 
     def initialize
       base_credentials =
-        Rails.application.credentials.ucpath&.with_indifferent_access || Rails.application.credentials.hcm&.with_indifferent_access
-      env_credentials = base_credentials&.fetch(Rails.env) || {}
+        Rails.application.credentials.ucpath&.with_indifferent_access ||
+        Rails.application.credentials.hcm&.with_indifferent_access ||
+        Rails.application.credentials.fetch(:"ucb-hcm", {})&.with_indifferent_access
+      env_credentials = base_credentials&.fetch(Rails.env, {})
       @app_id  = env_credentials&.fetch(:app_id, nil) || base_credentials&.fetch(:app_id, nil)
       @app_key = env_credentials&.fetch(:app_key, nil) || base_credentials&.fetch(:app_key, nil)
       @endpoint = env_credentials&.fetch(:endpoint, nil) || base_credentials&.fetch(:endpoint, nil)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,16 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_07_231505) do
-
+ActiveRecord::Schema[7.0].define(version: 2019_08_07_231505) do
   create_table "impersonations", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "target_id", null: false
@@ -36,9 +35,9 @@ ActiveRecord::Schema.define(version: 2019_08_07_231505) do
     t.string "alternate_last_name"
     t.string "alternate_email"
     t.boolean "alternate_flag", default: false, null: false
-    t.datetime "last_login_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "last_login_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["affiliate_id"], name: "index_users_on_affiliate_id", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["employee_id"], name: "index_users_on_employee_id", unique: true

--- a/spec/models/ucb_rails/user_session_manager/in_uc_path_add_to_users_table_spec.rb
+++ b/spec/models/ucb_rails/user_session_manager/in_uc_path_add_to_users_table_spec.rb
@@ -12,7 +12,7 @@ describe UcbRailsUser::UserSessionManager::InUcPathAddToUsersTable do
 
     it "pulls the record from UCPath if the user is not in the database, and stores the lived name" do
       ucpath_client = instance_double("UcbRailsUser::UserUcPathService::UcPathClient")
-      allow(ucpath_client).to receive(:fetch_employee_data).and_return(mock_ucpath_response["response"].first)
+      allow(ucpath_client).to receive(:fetch_employee_data_with_ldap_uid).and_return(mock_ucpath_response["response"].first)
       expect(UcbRailsUser::UserUcPathService).to receive(:ucpath_client).and_return(ucpath_client)
       expect(UcbRailsUser::UserLdapService).not_to receive(:create_or_update_user_from_entry)
       user = manager.login("1234")


### PR DESCRIPTION
This extends the work done in #84 so that a new user record can be created based on the employee id, for cases when the LDAP uid is not available.

This also improves the code that reads the UCPath credentials from the credentials file. It allows you to specify environment-specific settings if you so desire, e.g.
```
hcm:
  app_id: 1234
  app_key: abcd
  endpoint: https://some/url

  development:
    endpoint: https://some/other/url
```
In this case, all environments would use the app_id and app_key in the top of the block, but only `development` would use `https://some/other/url` as the endpoint.
