### PR TITLE
Check for valid email when syncing user data from LDAP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ucb_rails_user (4.1.0)
+    ucb_rails_user (4.1.1)
       active_attr (~> 0.10)
       faraday (~> 1.0)
       haml (~> 5.0)
@@ -119,7 +119,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.20.0)
       i18n (>= 1.8.11, < 2)
-    faraday (1.10.0)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -282,7 +282,7 @@ GEM
     strscan (3.0.4)
     temple (0.8.2)
     thor (1.2.1)
-    tilt (2.0.10)
+    tilt (2.0.11)
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)

--- a/app/models/ucb_rails_user/ldap_person/entry.rb
+++ b/app/models/ucb_rails_user/ldap_person/entry.rb
@@ -14,6 +14,7 @@ module UcbRailsUser::LdapPerson
     attribute :first_name
     attribute :last_name
     attribute :email
+    attribute :alternate_email
     attribute :phone
     attribute :departments
     attribute :affiliations
@@ -41,18 +42,19 @@ module UcbRailsUser::LdapPerson
 
       def new_from_ldap_entry(ldap_entry)
         new(
-          :uid => ldap_entry.uid,
-          :calnet_id => ldap_entry.berkeleyedukerberosprincipalstring.first,
-          :employee_id => ldap_entry.attributes[:berkeleyeduucpathid]&.first,
-          :student_id => ldap_entry.berkeleyedustuid,
-          :first_name => ldap_entry.givenname.first,
-          :last_name => ldap_entry.sn.first,
-          :email => ldap_entry.mail.first,
-          :phone => ldap_entry.phone,
-          :departments => ldap_entry.berkeleyeduunithrdeptname,
-          :affiliations => ldap_entry.berkeleyeduaffiliations,
-          :affiliate_id => ldap_entry.berkeleyeduaffid.first,
-          :inactive => ldap_entry.expired? || false
+          uid: ldap_entry.uid,
+          calnet_id: ldap_entry.berkeleyedukerberosprincipalstring.first,
+          employee_id: ldap_entry.attributes[:berkeleyeduucpathid]&.first,
+          student_id: ldap_entry.berkeleyedustuid,
+          first_name: ldap_entry.givenname.first,
+          last_name: ldap_entry.sn.first,
+          email: ldap_entry.mail.first,
+          alternate_email: ldap_entry.attributes[:berkeleyeduofficialemail]&.first,
+          phone: ldap_entry.phone,
+          departments: ldap_entry.berkeleyeduunithrdeptname,
+          affiliations: ldap_entry.berkeleyeduaffiliations,
+          affiliate_id: ldap_entry.berkeleyeduaffid.first,
+          inactive: ldap_entry.expired? || false
         )
       end
 

--- a/app/models/ucb_rails_user/user_session_manager/in_people_ou_add_to_users_table.rb
+++ b/app/models/ucb_rails_user/user_session_manager/in_people_ou_add_to_users_table.rb
@@ -8,11 +8,20 @@ module UcbRailsUser
 
         if people_ou_entry.present?
           UcbRailsUser::UserLdapService.create_or_update_user_from_entry(people_ou_entry).tap do |user|
+            if missing_or_invalid_email?(user)
+              user.update(email: people_ou_entry.alternate_email) if people_ou_entry.alternate_email.present?
+            end
             user.touch(:last_login_at)
           end
         else
           nil
         end
+      end
+
+      private
+
+      def missing_or_invalid_email?(user)
+        user&.email.blank? || (user.email =~ URI::MailTo::EMAIL_REGEXP).nil?
       end
 
     end


### PR DESCRIPTION
We had a case where a user had an invalid email address in the LDAP field that we usually look in. So this adds a check to make sure the email is valid, and, if not, to look in one of the alternate email fields.