### PR TITLE
Properly convert LDAP strings to Oracle-friendly strings

### DIFF
--- a/app/models/ucb_rails_user/ldap_person/entry.rb
+++ b/app/models/ucb_rails_user/ldap_person/entry.rb
@@ -41,19 +41,22 @@ module UcbRailsUser::LdapPerson
     class << self
 
       def new_from_ldap_entry(ldap_entry)
+        # the to_s calls are because the underlying LDAP library sometimes returns strings as instances
+        # of Net::BER::BerIdentifiedString rather than String, and the Oracle DB library doesn't play
+        # nicely with those (postgres and sqlite work fine)
         new(
-          uid: ldap_entry.uid,
-          calnet_id: ldap_entry.berkeleyedukerberosprincipalstring.first,
-          employee_id: ldap_entry.attributes[:berkeleyeduucpathid]&.first,
-          student_id: ldap_entry.berkeleyedustuid,
-          first_name: ldap_entry.givenname.first,
-          last_name: ldap_entry.sn.first,
-          email: ldap_entry.mail.first,
-          alternate_email: ldap_entry.attributes[:berkeleyeduofficialemail]&.first,
-          phone: ldap_entry.phone,
-          departments: ldap_entry.berkeleyeduunithrdeptname,
-          affiliations: ldap_entry.berkeleyeduaffiliations,
-          affiliate_id: ldap_entry.berkeleyeduaffid.first,
+          uid: ldap_entry.uid&.to_s,
+          calnet_id: ldap_entry.berkeleyedukerberosprincipalstring.first&.to_s,
+          employee_id: ldap_entry.attributes[:berkeleyeduucpathid]&.first&.to_s,
+          student_id: ldap_entry.berkeleyedustuid&.to_s,
+          first_name: ldap_entry.givenname.first&.to_s,
+          last_name: ldap_entry.sn.first&.to_s,
+          email: ldap_entry.mail.first&.to_s,
+          alternate_email: ldap_entry.attributes[:berkeleyeduofficialemail]&.first&.to_s,
+          phone: ldap_entry.phone&.to_s,
+          departments: ldap_entry.berkeleyeduunithrdeptname&.to_s,
+          affiliations: ldap_entry.berkeleyeduaffiliations&.map(&:to_s),
+          affiliate_id: ldap_entry.berkeleyeduaffid.first&.to_s,
           inactive: ldap_entry.expired? || false
         )
       end


### PR DESCRIPTION
The standard Ruby LDAP library often returns string values as instances of `Net::BER::BerIdentifiedString` rather than `String`. That class implements to the `to_s` so generally it drops in as a replacement for `String` without trouble, but the Oracle ActiveRecord adapter doesn't like it. 

This manually calls `to_s` on strings fetched from LDAP so that they can go into Oracle without incident.