### PR TITLE
Make sprockets a dev dependency, not a gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,7 @@ DEPENDENCIES
   rspec-rails (~> 5.0)
   selenium-webdriver
   simplecov
+  sprockets-rails
   sqlite3
   ucb_rails_user!
 

--- a/ucb_rails_user.gemspec
+++ b/ucb_rails_user.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "> 5.2", "< 8.0"
-  s.add_dependency "sprockets-rails"
 
   s.add_dependency "haml", "~> 5.0"
   s.add_dependency "haml-rails", "~> 2.0"

--- a/ucb_rails_user.gemspec
+++ b/ucb_rails_user.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 5.0"
   s.add_development_dependency "factory_bot_rails"
   s.add_development_dependency "faker"
+  s.add_development_dependency "sprockets-rails"
   s.add_development_dependency "capybara", "~> 3.0"
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "selenium-webdriver"


### PR DESCRIPTION
Sprockets was mistakenly added as a gem dependency, which was confusing host apps that are trying to make the switch to propshaft. This changes it to a dev dependency, so that it's still available for running system tests.